### PR TITLE
feat(datasource): add TiDB data source type support

### DIFF
--- a/src/common/datasource/index.tsx
+++ b/src/common/datasource/index.tsx
@@ -23,6 +23,7 @@ import SqlServer from './sqlserver';
 import oracle from './oracle';
 import MySQL from './mysql';
 import Doris from './doris';
+import TiDB from './tidb';
 import PG from './pg';
 import DM from './dm';
 import FileSystem from './fileSystem';
@@ -31,8 +32,10 @@ import { ReactComponent as DBOBSvg } from '@/svgr/database_oceanbase.svg';
 import { ReactComponent as MySQLSvg } from '@/svgr/mysql.svg';
 import { ReactComponent as DBMySQLSvg } from '@/svgr/database_mysql.svg';
 import { ReactComponent as DorisSvg } from '@/svgr/doris.svg';
+import { ReactComponent as TiDBSvg } from '@/svgr/tidb.svg';
 import { ReactComponent as PGSvg } from '@/svgr/pg.svg';
 import { ReactComponent as DBDorisSvg } from '@/svgr/database_doris.svg';
+import { ReactComponent as DBTiDBSvg } from '@/svgr/database_tidb.svg';
 import { ReactComponent as OracleSvg } from '@/svgr/oracle.svg';
 import { ReactComponent as DBOracleSvg } from '@/svgr/database_oracle.svg';
 import { DBType, BooleanOptionType } from '@/d.ts/database';
@@ -96,6 +99,15 @@ const _styles = {
     },
     dbIcon: {
       component: DBDorisSvg
+    }
+  },
+  [IDataSourceType.TiDB]: {
+    icon: {
+      component: TiDBSvg,
+      color: '#E4002B'
+    },
+    dbIcon: {
+      component: DBTiDBSvg
     }
   },
   [IDataSourceType.Oracle]: {
@@ -167,6 +179,7 @@ const _gruops = {
   [IDataSourceType.OceanBase]: DatasourceGroup.OceanBaseDatabase,
   [IDataSourceType.MySQL]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.Doris]: DatasourceGroup.OtherDatabase,
+  [IDataSourceType.TiDB]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.Oracle]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.PG]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.ALIYUNOSS]: DatasourceGroup.FileSystem,
@@ -224,6 +237,7 @@ function initDatasource() {
   register(IDataSourceType.OceanBase, obMySQL);
   register(IDataSourceType.MySQL, MySQL);
   register(IDataSourceType.Doris, Doris);
+  register(IDataSourceType.TiDB, TiDB);
   register(IDataSourceType.Oracle, oracle);
   register(IDataSourceType.PG, PG);
   register(IDataSourceType.ALIYUNOSS, FileSystem.ALIYUN);

--- a/src/common/datasource/tidb/index.tsx
+++ b/src/common/datasource/tidb/index.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 OceanBase
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConnectType, TaskType } from '@/d.ts';
+import { IDataSourceModeConfig } from '../interface';
+import MySQLColumnExtra from '../oceanbase/MySQLColumnExtra';
+import { haveOCP } from '@/util/env';
+
+const tableConfig = {
+  enableTableCharsetsAndCollations: true,
+  enableConstraintOnUpdate: true,
+  ColumnExtraComponent: MySQLColumnExtra,
+  paritionNameCaseSensitivity: true,
+  enableIndexesFullTextType: true,
+  enableAutoIncrement: true,
+  type2ColumnType: {
+    id: 'int',
+    name: 'varchar',
+    date: 'datetime',
+    time: 'timestamp'
+  }
+};
+
+const functionConfig: IDataSourceModeConfig['schema']['func'] = {
+  params: ['paramName', 'dataType', 'dataLength'],
+  defaultValue: {
+    dataLength: 45
+  },
+  dataNature: true,
+  sqlSecurity: true,
+  deterministic: true
+};
+
+const procedureConfig: IDataSourceModeConfig['schema']['proc'] = {
+  params: ['paramName', 'paramMode', 'dataType', 'dataLength'],
+  defaultValue: {
+    dataLength: 45
+  },
+  dataNature: true,
+  sqlSecurity: true,
+  deterministic: true
+};
+
+const items: Record<ConnectType.TIDB, IDataSourceModeConfig> = {
+  [ConnectType.TIDB]: {
+    connection: {
+      address: {
+        items: ['ip', 'port']
+      },
+      account: true,
+      sys: false,
+      ssl: false,
+      jdbcDoc:
+        'https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html'
+    },
+    features: {
+      task: [
+        TaskType.ASYNC,
+        TaskType.SQL_PLAN,
+        TaskType.IMPORT,
+        TaskType.EXPORT,
+        TaskType.EXPORT_RESULT_SET,
+        TaskType.MULTIPLE_ASYNC
+      ],
+      obclient: true,
+      recycleBin: false,
+      sessionManage: true,
+      sessionParams: true,
+      groupResourceTree: true,
+      sqlconsole: true,
+      sqlExplain: true,
+      export: {
+        fileLimit: false,
+        snapshot: false
+      }
+    },
+    schema: {
+      table: tableConfig,
+      func: functionConfig,
+      proc: procedureConfig,
+      innerSchema: ['information_schema', 'mysql', 'performance_schema', 'metrics_schema', 'sys']
+    },
+    sql: {
+      language: 'mysql',
+      escapeChar: '`',
+      caseSensitivity: true
+    }
+  }
+};
+
+if (haveOCP()) {
+  delete items[ConnectType.TIDB];
+}
+
+export default items;

--- a/src/constant/label.ts
+++ b/src/constant/label.ts
@@ -130,6 +130,7 @@ export const ConnectTypeText = (type: ConnectType) => {
     [ConnectType.ODP_SHARDING_OB_MYSQL]: 'OB Sharding MySQL',
     [ConnectType.MYSQL]: 'MySQL',
     [ConnectType.DORIS]: 'Doris',
+    [ConnectType.TIDB]: 'TiDB',
     [ConnectType.ORACLE]: 'Oracle',
     [ConnectType.PG]: 'PostgreSQL',
     [ConnectType.OSS]: formatMessage({

--- a/src/d.ts/datasource.ts
+++ b/src/d.ts/datasource.ts
@@ -48,6 +48,7 @@ export enum IDataSourceType {
   OceanBase = 'ob',
   MySQL = 'mysql',
   Doris = 'doris',
+  TiDB = 'tidb',
   Oracle = 'oracle',
   PG = 'postgresql',
   ALIYUNOSS = 'ALIYUNOSS',

--- a/src/d.ts/index.ts
+++ b/src/d.ts/index.ts
@@ -699,6 +699,7 @@ export enum AuditEventDialectType {
   ORACLE = 'ORACLE',
   MYSQL = 'MYSQL',
   DORIS = 'DORIS',
+  TIDB = 'TIDB',
   PG = 'POSTGRESQL',
   UNKNOWN = 'UNKNOWN'
 }
@@ -763,6 +764,7 @@ export type ISQLScript = IScriptMeta;
 export enum ConnectionMode {
   MYSQL = 'MYSQL',
   DORIS = 'DORIS',
+  TIDB = 'TIDB',
   PG = 'POSTGRESQL',
   ORACLE = 'ORACLE',
   OB_MYSQL = 'OB_MYSQL',
@@ -3550,6 +3552,7 @@ export enum ConnectType {
   ODP_SHARDING_OB_MYSQL = 'ODP_SHARDING_OB_MYSQL',
   MYSQL = 'MYSQL',
   DORIS = 'DORIS',
+  TIDB = 'TIDB',
   PG = 'POSTGRESQL',
   ORACLE = 'ORACLE',
   OSS = 'OSS',

--- a/src/svgr/database_tidb.svg
+++ b/src/svgr/database_tidb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="13" height="13">
+  <rect x="0" y="0" width="512" height="512" rx="64" fill="#E4002B"/>
+  <text x="256" y="320" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="240" fill="white" text-anchor="middle">Ti</text>
+</svg>

--- a/src/svgr/tidb.svg
+++ b/src/svgr/tidb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="13" height="13">
+  <rect x="0" y="0" width="512" height="512" rx="64" fill="#E4002B"/>
+  <text x="256" y="320" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="240" fill="white" text-anchor="middle">Ti</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add TiDB as a new datasource type with ConnectType, IDataSourceType, and ConnectionMode entries
- Register TiDB datasource configuration inheriting MySQL-compatible settings
- Add TiDB SVG icons for datasource display

Fixes https://github.com/actiontech/dms-ee/issues/811