### PR TITLE
feat(client): read-only trigger UI gates for MySQL and SQL Server (v2)

### DIFF
--- a/src/common/datasource/mysql/index.tsx
+++ b/src/common/datasource/mysql/index.tsx
@@ -88,6 +88,7 @@ const items: Record<ConnectType.MYSQL, IDataSourceModeConfig> = {
       sessionParams: true,
       groupResourceTree: true,
       sqlconsole: true,
+      disableTriggerSwitch: true,
       export: {
         fileLimit: false,
         snapshot: false

--- a/src/common/datasource/sqlserver/index.tsx
+++ b/src/common/datasource/sqlserver/index.tsx
@@ -88,6 +88,7 @@ const items: Record<ConnectType.SQL_SERVER, IDataSourceModeConfig> = {
       sessionParams: true,
       groupResourceTree: true,
       sqlconsole: true,
+      disableTriggerSwitch: true,
       export: {
         fileLimit: false,
         snapshot: false

--- a/src/constant/version.ts
+++ b/src/constant/version.ts
@@ -1,1 +1,1 @@
-export const UI_VERSION = 'feature/support-sqlserver-editor-v2   92ff02a4';
+export const UI_VERSION = 'dev-4.3.4-v2   a4e1492d';

--- a/src/page/Workspace/SideBar/ResourceTree/Nodes/trigger.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/Nodes/trigger.tsx
@@ -48,25 +48,24 @@ export function TriggerTreeData(
   };
   if (triggers) {
     treeData.children = triggers.map((trigger) => {
-      const title =
-        trigger.enableState === TriggerState.enabled
-          ? formatMessage({
-              id: 'odc.ResourceTree.config.procedure.Enable',
-              defaultMessage: '启用'
-            }) // 启用
-          : formatMessage({
-              id: 'odc.ResourceTree.config.procedure.Disable',
-              defaultMessage: '禁用'
-            }); // 禁用
+      const enabled =
+        trigger.enableState === TriggerState.enabled ||
+        trigger.enableState == null;
+      const title = enabled
+        ? formatMessage({
+            id: 'odc.ResourceTree.config.procedure.Enable',
+            defaultMessage: '启用'
+          }) // 启用
+        : formatMessage({
+            id: 'odc.ResourceTree.config.procedure.Disable',
+            defaultMessage: '禁用'
+          }); // 禁用
       const icon = (
         <Tooltip placement="right" title={title}>
           <Icon
             component={TriggerSvg}
             style={{
-              color:
-                trigger.enableState === TriggerState.enabled
-                  ? THEME.TRIGGER_ENABLE
-                  : THEME.TRIGGER_DISABLE
+              color: enabled ? THEME.TRIGGER_ENABLE : THEME.TRIGGER_DISABLE
             }}
           />
         </Tooltip>
@@ -80,7 +79,7 @@ export function TriggerTreeData(
           openTriggerViewPage(
             trigger.triggerName,
             undefined,
-            trigger.enableState,
+            enabled ? TriggerState.enabled : TriggerState.disabled,
             undefined,
             session?.database?.databaseId
           );

--- a/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/trigger.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/trigger.tsx
@@ -90,6 +90,9 @@ export const triggerMenusConfig: Partial<
       ],
       actionType: actionTypes.create,
       icon: PlusOutlined,
+      isHide(session) {
+        return !session?.supportFeature?.enableTriggerDDL;
+      },
       run(session, node) {
         openCreateTriggerPage(
           null,

--- a/src/page/Workspace/components/TriggerPage/index.tsx
+++ b/src/page/Workspace/components/TriggerPage/index.tsx
@@ -544,14 +544,16 @@ class TriggerPage extends Component<
                   children: (
                     <>
                       <Toolbar>
-                        <ToolbarButton
-                          text={formatMessage({
-                            id: 'workspace.window.session.button.edit',
-                            defaultMessage: '编辑'
-                          })}
-                          icon={<EditOutlined />}
-                          onClick={this.editTrigger}
-                        />
+                        {session?.supportFeature?.enableTriggerDDL && (
+                          <ToolbarButton
+                            text={formatMessage({
+                              id: 'workspace.window.session.button.edit',
+                              defaultMessage: '编辑'
+                            })}
+                            icon={<EditOutlined />}
+                            onClick={this.editTrigger}
+                          />
+                        )}
 
                         <ToolbarButton
                           text={


### PR DESCRIPTION
## Summary

Frontend read-only trigger gates for **dev-4.3.4-v2** (priority).

- Gate `CREATE_TRIGGER` by session capabilities
- `disableTriggerSwitch: true` for MySQL / SQL Server

Tracking: actiontech/sqle-ee#2967 | Backend: actiontech/odc PR (v2)


Made with [Cursor](https://cursor.com)