### PR TITLE
feat(client): read-only trigger UI gates for MySQL and SQL Server (4.3.4)

### DIFF
--- a/src/common/datasource/mysql/index.tsx
+++ b/src/common/datasource/mysql/index.tsx
@@ -88,6 +88,7 @@ const items: Record<ConnectType.MYSQL, IDataSourceModeConfig> = {
       sessionParams: true,
       groupResourceTree: true,
       sqlconsole: true,
+      disableTriggerSwitch: true,
       export: {
         fileLimit: false,
         snapshot: false

--- a/src/common/datasource/sqlserver/index.tsx
+++ b/src/common/datasource/sqlserver/index.tsx
@@ -88,6 +88,7 @@ const items: Record<ConnectType.SQL_SERVER, IDataSourceModeConfig> = {
       sessionParams: true,
       groupResourceTree: true,
       sqlconsole: true,
+      disableTriggerSwitch: true,
       export: {
         fileLimit: false,
         snapshot: false

--- a/src/page/Workspace/SideBar/ResourceTree/Nodes/trigger.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/Nodes/trigger.tsx
@@ -48,25 +48,24 @@ export function TriggerTreeData(
   };
   if (triggers) {
     treeData.children = triggers.map((trigger) => {
-      const title =
-        trigger.enableState === TriggerState.enabled
-          ? formatMessage({
-              id: 'odc.ResourceTree.config.procedure.Enable',
-              defaultMessage: '启用'
-            }) // 启用
-          : formatMessage({
-              id: 'odc.ResourceTree.config.procedure.Disable',
-              defaultMessage: '禁用'
-            }); // 禁用
+      const enabled =
+        trigger.enableState === TriggerState.enabled ||
+        trigger.enableState == null;
+      const title = enabled
+        ? formatMessage({
+            id: 'odc.ResourceTree.config.procedure.Enable',
+            defaultMessage: '启用'
+          }) // 启用
+        : formatMessage({
+            id: 'odc.ResourceTree.config.procedure.Disable',
+            defaultMessage: '禁用'
+          }); // 禁用
       const icon = (
         <Tooltip placement="right" title={title}>
           <Icon
             component={TriggerSvg}
             style={{
-              color:
-                trigger.enableState === TriggerState.enabled
-                  ? THEME.TRIGGER_ENABLE
-                  : THEME.TRIGGER_DISABLE
+              color: enabled ? THEME.TRIGGER_ENABLE : THEME.TRIGGER_DISABLE
             }}
           />
         </Tooltip>
@@ -80,7 +79,7 @@ export function TriggerTreeData(
           openTriggerViewPage(
             trigger.triggerName,
             undefined,
-            trigger.enableState,
+            enabled ? TriggerState.enabled : TriggerState.disabled,
             undefined,
             session?.database?.databaseId
           );

--- a/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/trigger.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/trigger.tsx
@@ -90,6 +90,9 @@ export const triggerMenusConfig: Partial<
       ],
       actionType: actionTypes.create,
       icon: PlusOutlined,
+      isHide(session) {
+        return !session?.supportFeature?.enableTriggerDDL;
+      },
       run(session, node) {
         openCreateTriggerPage(
           null,

--- a/src/page/Workspace/components/TriggerPage/index.tsx
+++ b/src/page/Workspace/components/TriggerPage/index.tsx
@@ -544,14 +544,16 @@ class TriggerPage extends Component<
                   children: (
                     <>
                       <Toolbar>
-                        <ToolbarButton
-                          text={formatMessage({
-                            id: 'workspace.window.session.button.edit',
-                            defaultMessage: '编辑'
-                          })}
-                          icon={<EditOutlined />}
-                          onClick={this.editTrigger}
-                        />
+                        {session?.supportFeature?.enableTriggerDDL && (
+                          <ToolbarButton
+                            text={formatMessage({
+                              id: 'workspace.window.session.button.edit',
+                              defaultMessage: '编辑'
+                            })}
+                            icon={<EditOutlined />}
+                            onClick={this.editTrigger}
+                          />
+                        )}
 
                         <ToolbarButton
                           text={


### PR DESCRIPTION
## Summary

Frontend read-only trigger gates cherry-picked onto **dev-4.3.4** (feat commit only; no `version.ts` change).

Tracking: actiontech/sqle-ee#2967 | Backend: actiontech/odc PR (4.3.4)


Made with [Cursor](https://cursor.com)