### PR TITLE
feat: add Redis datasource UI helpers #873

### DIFF
--- a/src/common/datasource/index.tsx
+++ b/src/common/datasource/index.tsx
@@ -29,6 +29,7 @@ import GaussDB from './gaussdb';
 import DM from './dm';
 import Hana from './hana';
 import MongoDB from './mongodb';
+import Redis from './redis';
 import Hive from './hive';
 import DB2 from './db2';
 import FileSystem from './fileSystem';
@@ -214,6 +215,15 @@ const _styles = {
       component: DBMongoDBSvg
     }
   },
+  [IDataSourceType.Redis]: {
+    icon: {
+      component: MongoDBSvg,
+      color: '#d82c20'
+    },
+    dbIcon: {
+      component: DBMongoDBSvg
+    }
+  },
   // Hive reuses the generic database SVG assets to avoid shipping new
   // image binaries, following the same pattern as GaussDB reusing PG icons.
   [IDataSourceType.HIVE]: {
@@ -252,6 +262,7 @@ const _gruops = {
   [IDataSourceType.DM]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.HANA]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.MongoDB]: DatasourceGroup.OtherDatabase,
+  [IDataSourceType.Redis]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.HIVE]: DatasourceGroup.OtherDatabase,
   [IDataSourceType.DB2]: DatasourceGroup.OtherDatabase
 };
@@ -315,6 +326,7 @@ function initDatasource() {
   register(IDataSourceType.DM, DM);
   register(IDataSourceType.HANA, Hana);
   register(IDataSourceType.MongoDB, MongoDB);
+  register(IDataSourceType.Redis, Redis);
   register(IDataSourceType.HIVE, Hive);
   register(IDataSourceType.DB2, DB2);
 }

--- a/src/common/datasource/redis/index.tsx
+++ b/src/common/datasource/redis/index.tsx
@@ -1,0 +1,51 @@
+import { ConnectType, TaskType } from '@/d.ts';
+import { IDataSourceModeConfig } from '../interface';
+
+const items: Record<ConnectType.REDIS, IDataSourceModeConfig> = {
+  [ConnectType.REDIS]: {
+    connection: {
+      address: {
+        items: ['ip', 'port']
+      },
+      account: true,
+      sys: false,
+      ssl: true,
+      defaultSchema: true,
+      disableURLParse: true
+    },
+    features: {
+      task: [TaskType.ASYNC],
+      obclient: false,
+      recycleBin: false,
+      plRun: false,
+      sessionManage: false,
+      sqlExplain: false,
+      sessionParams: false,
+      groupResourceTree: true,
+      sqlconsole: true,
+      export: {
+        fileLimit: false,
+        snapshot: false
+      }
+    },
+    schema: {
+      table: {
+        enableAutoIncrement: false
+      },
+      func: {
+        params: ['paramName']
+      },
+      proc: {
+        params: ['paramName']
+      },
+      innerSchema: []
+    },
+    sql: {
+      language: 'redis',
+      escapeChar: '',
+      caseSensitivity: true
+    }
+  }
+};
+
+export default items;

--- a/src/component/TemplateInsertModal/index.tsx
+++ b/src/component/TemplateInsertModal/index.tsx
@@ -19,6 +19,7 @@ import { getView } from '@/common/network/view';
 import { DragInsertTypeText } from '@/constant/label';
 import { DbObjectType, DragInsertType } from '@/d.ts/index';
 import { generateMongoCopyText, isMongoConnectType } from '@/util/mongodb';
+import { generateRedisCopyText, isRedisConnectType } from '@/util/redis';
 import type { ModalStore } from '@/store/modal';
 import sessionManager from '@/store/sessionManager';
 import SessionStore from '@/store/sessionManager/session';
@@ -293,6 +294,10 @@ export async function getCopyText(
       isExternalTable
     );
     return _escape(generateMongoCopyText(name, copyType, columnNames));
+  }
+
+  if (isRedisConnectType(dbSession?.connection?.type)) {
+    return _escape(generateRedisCopyText(name, copyType));
   }
 
   switch (copyType) {

--- a/src/d.ts/datasource.ts
+++ b/src/d.ts/datasource.ts
@@ -60,6 +60,7 @@ export enum IDataSourceType {
   DM = 'DM',
   HANA = 'HANA',
   MongoDB = 'mongodb',
+  Redis = 'redis',
   HIVE = 'HIVE',
   DB2 = 'DB2'
 }

--- a/src/d.ts/index.ts
+++ b/src/d.ts/index.ts
@@ -3569,6 +3569,7 @@ export enum ConnectType {
   DM = 'DM',
   HANA = 'HANA',
   MONGODB = 'MONGODB',
+  REDIS = 'REDIS',
   HIVE = 'HIVE',
   DB2 = 'DB2'
 }

--- a/src/page/Workspace/SideBar/ResourceTree/Nodes/table.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/Nodes/table.tsx
@@ -74,7 +74,7 @@ export function TableTreeData(
         visited.add(table.info?.tableName);
         const tableKey = `${database.id}-${dbName}-table-${table?.info?.tableName}`;
         let columnRoot: TreeDataNode;
-        if (table.columns) {
+        if (!isMongoDB && table.columns) {
           columnRoot = {
             title: formatMessage({
               id: 'odc.ResourceTree.Nodes.table.Column',
@@ -238,12 +238,13 @@ export function TableTreeData(
           ),
 
           sessionId: dbSession?.sessionId,
-          isLeaf: false,
-          children: table.columns
-            ? [columnRoot, indexRoot, partitionRoot, constraintRoot].filter(
-                Boolean
-              )
-            : null
+          isLeaf: isMongoDB,
+          children:
+            !isMongoDB && table.columns
+              ? [columnRoot, indexRoot, partitionRoot, constraintRoot].filter(
+                  Boolean
+                )
+              : null
         };
       })
       .filter(Boolean);

--- a/src/page/Workspace/SideBar/ResourceTree/Nodes/table.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/Nodes/table.tsx
@@ -35,7 +35,7 @@ import { ReactComponent as IndexSvg } from '@/svgr/index.svg';
 import { ReactComponent as TableOutlined } from '@/svgr/menuTable.svg';
 import { ReactComponent as PartitionSvg } from '@/svgr/Partition.svg';
 import logger from '@/util/logger';
-import { isMongoConnectType } from '@/util/mongodb';
+import { isDocumentOrKeyValueSession } from '@/util/mongodb';
 import { ITableModel } from '@/page/Workspace/components/CreateTable/interface';
 
 export function TableTreeData(
@@ -44,7 +44,7 @@ export function TableTreeData(
 ): TreeDataNode {
   const dbName = database.name;
   const tables = dbSession?.database?.tables;
-  const isMongoDB = isMongoConnectType(dbSession?.connection?.type);
+  const isMongoDB = isDocumentOrKeyValueSession(dbSession);
   const treeData: TreeDataNode = {
     title: formatMessage({
       id: 'odc.ResourceTree.Nodes.table.Table',

--- a/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/table.tsx
+++ b/src/page/Workspace/SideBar/ResourceTree/TreeNodeMenu/config/table.tsx
@@ -51,7 +51,7 @@ import { isSupportExport } from './helper';
 import { isLogicalDatabase } from '@/util/database';
 import { DatabasePermissionType } from '@/d.ts/database';
 import { generateDMSExportUrl } from '@/util/dms/export';
-import { isMongoDBSession } from '@/util/mongodb';
+import { isDocumentOrKeyValueSession } from '@/util/mongodb';
 
 export const tableMenusConfig: Partial<
   Record<ResourceNodeType, IMenuItemConfig[]>
@@ -76,7 +76,7 @@ export const tableMenusConfig: Partial<
         openCreateTablePage(session?.odcDatabase?.id);
       },
       isHide(session, node) {
-        if (isMongoDBSession(session)) {
+        if (isDocumentOrKeyValueSession(session)) {
           return true;
         }
         if (isLogicalDatabase(node.data)) {
@@ -123,7 +123,7 @@ export const tableMenusConfig: Partial<
         openTableViewPage(
           (node.data as ITableModel)?.info?.tableName,
           TopTab.PROPS,
-          isMongoDBSession(session) ? PropsTab.INFO : PropsTab.DDL,
+          isDocumentOrKeyValueSession(session) ? PropsTab.INFO : PropsTab.DDL,
           session?.odcDatabase?.id,
           node?.data?.info?.tableId
         );
@@ -209,7 +209,7 @@ export const tableMenusConfig: Partial<
       },
       isHide: (session) => {
         return (
-          isMongoDBSession(session) ||
+          isDocumentOrKeyValueSession(session) ||
           !isSupportExport(session) ||
           isLogicalDatabase(session?.odcDatabase)
         );
@@ -240,7 +240,8 @@ export const tableMenusConfig: Partial<
       ellipsis: true,
       isHide: (session) => {
         return (
-          isMongoDBSession(session) || isLogicalDatabase(session?.odcDatabase)
+          isDocumentOrKeyValueSession(session) ||
+          isLogicalDatabase(session?.odcDatabase)
         );
       },
       async run(session, node) {
@@ -564,7 +565,7 @@ export const tableMenusConfig: Partial<
       ],
 
       ellipsis: true,
-      isHide: (session) => isMongoDBSession(session),
+      isHide: (session) => isDocumentOrKeyValueSession(session),
       run(session, node) {
         const table = node.data as ITableModel;
         const tableName = table?.info?.tableName;
@@ -587,7 +588,7 @@ export const tableMenusConfig: Partial<
       ],
 
       ellipsis: true,
-      isHide: (session) => isMongoDBSession(session),
+      isHide: (session) => isDocumentOrKeyValueSession(session),
       async run(session, node) {
         const table = node.data as ITableModel;
         await session.database.loadTable(table.info);
@@ -606,7 +607,7 @@ export const tableMenusConfig: Partial<
       ],
 
       ellipsis: true,
-      isHide: (session) => isMongoDBSession(session),
+      isHide: (session) => isDocumentOrKeyValueSession(session),
       run(session, node) {
         const table = node.data as ITableModel;
         const tableName = table?.info?.tableName;
@@ -629,7 +630,7 @@ export const tableMenusConfig: Partial<
       ],
 
       ellipsis: true,
-      isHide: (session) => isMongoDBSession(session),
+      isHide: (session) => isDocumentOrKeyValueSession(session),
       async run(session, node) {
         const table = node.data as ITableModel;
         await session.database.loadTable(table.info);
@@ -648,7 +649,7 @@ export const tableMenusConfig: Partial<
       ],
 
       ellipsis: true,
-      isHide: (session) => isMongoDBSession(session),
+      isHide: (session) => isDocumentOrKeyValueSession(session),
       run(session, node) {
         const table = node.data as ITableModel;
         const tableName = table?.info?.tableName;

--- a/src/page/Workspace/components/TablePage/ShowTableBaseInfoForm/index.tsx
+++ b/src/page/Workspace/components/TablePage/ShowTableBaseInfoForm/index.tsx
@@ -34,7 +34,6 @@ import { cloneDeep } from 'lodash';
 import TableContext from '../../CreateTable/TableContext';
 import TablePageContext from '../context';
 import { DBType } from '@/d.ts/database';
-import { ConnectType } from '@/d.ts';
 import LogicTableBaseInfo from './LogicTableBaseInfo';
 import {
   PropsTab as TablePropsTab,
@@ -42,6 +41,7 @@ import {
 } from '@/page/Workspace/components/TablePage';
 import { TableBaseInfoFormStyleWrapper } from './style';
 import { BasicButton } from '@actiontech/dms-kit';
+import { isDocumentOrKeyValueSession } from '@/util/mongodb';
 
 interface IProps {
   pageKey?: string;
@@ -59,7 +59,7 @@ const ShowTableBaseInfoForm: React.FC<IProps> = ({
   const table = tableContext?.table;
   const [isEditing, setIsEditing] = useState(false);
   const formRef = useRef<FormInstance<any>>();
-  const isMongoDB = session?.connection?.type === ConnectType.MONGODB;
+  const isDocumentOrKeyValue = isDocumentOrKeyValueSession(session);
 
   return (
     <TableBaseInfoFormStyleWrapper>
@@ -164,7 +164,7 @@ const ShowTableBaseInfoForm: React.FC<IProps> = ({
           ) : (
             <Toolbar>
               {/* 外表与 MongoDB 集合不支持编辑 */}
-              {isExternalTable || isMongoDB ? null : (
+              {isExternalTable || isDocumentOrKeyValue ? null : (
                 <Toolbar.Button
                   icon={<EditOutlined />}
                   text={formatMessage({

--- a/src/page/Workspace/components/TablePage/TableData/index.tsx
+++ b/src/page/Workspace/components/TablePage/TableData/index.tsx
@@ -21,13 +21,7 @@ import {
 } from '@/common/network/table';
 import ExecuteSQLModal from '@/component/ExecuteSQLModal';
 import { ISQLLintReuslt } from '@/component/SQLLintResult/type';
-import {
-  EStatus,
-  IResultSet,
-  ISqlExecuteResultStatus,
-  ITable,
-  ConnectType
-} from '@/d.ts';
+import { EStatus, IResultSet, ISqlExecuteResultStatus, ITable } from '@/d.ts';
 import { generateResultSetColumns } from '@/store/helper';
 import modal, { ModalStore } from '@/store/modal';
 import { PageStore } from '@/store/page';
@@ -37,6 +31,7 @@ import { SettingStore } from '@/store/setting';
 import type { SQLStore } from '@/store/sql';
 import { formatMessage } from '@/util/intl';
 import notification from '@/util/notification';
+import { isDocumentOrKeyValueSession } from '@/util/mongodb';
 import { generateSelectSql } from '@/util/sql';
 import { generateUniqKey } from '@/util/utils';
 import { message, Spin } from 'antd';
@@ -438,7 +433,7 @@ class TableData extends React.Component<
             disableEdit={
               !resultSet.resultSetMetaData?.editable ||
               isExternalTable ||
-              session?.connection?.type === ConnectType.MONGODB
+              isDocumentOrKeyValueSession(session)
             }
             table={{
               ...table,

--- a/src/page/Workspace/components/TablePage/index.tsx
+++ b/src/page/Workspace/components/TablePage/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import { getTableInfo, getLogicTableInfo } from '@/common/network/table';
-import { ConnectType, TaskType } from '@/d.ts';
+import { TaskType } from '@/d.ts';
 import { PageStore } from '@/store/page';
 import { SettingStore } from '@/store/setting';
 import { formatMessage } from '@/util/intl';
@@ -52,6 +52,7 @@ import SessionContext from '../SessionContextWrap/context';
 import WrapSessionPage from '../SessionContextWrap/SessionPageWrap';
 import styles from './index.less';
 import { isLogicalDatabase } from '@/util/database';
+import { isDocumentOrKeyValueSession } from '@/util/mongodb';
 import { BasicSegmented, BasicSegmentedProps } from '@actiontech/dms-kit';
 import { TableDetailInfoPageStyleWrapper } from './style';
 
@@ -102,10 +103,10 @@ const TablePage: React.FC<IProps> = function ({
   const { session } = useContext(SessionContext);
   const dbType = session?.odcDatabase?.type;
   const dbName = session?.database?.dbName;
-  const isMongoDB = session?.connection?.type === ConnectType.MONGODB;
+  const isDocumentOrKeyValue = isDocumentOrKeyValueSession(session);
   const showPartition = !!table?.partitions?.partType;
   const enableConstraint =
-    !isMongoDB && !!session?.supportFeature?.enableConstraint;
+    !isDocumentOrKeyValue && !!session?.supportFeature?.enableConstraint;
   const callbackRef = useRef<any>();
   async function fetchTable() {
     if (table?.info?.tableName === params.tableName) {
@@ -183,7 +184,7 @@ const TablePage: React.FC<IProps> = function ({
     if (params.propsTab) {
       let nextPropsTab = params.propsTab;
       if (
-        isMongoDB &&
+        isDocumentOrKeyValue &&
         [
           PropsTab.DDL,
           PropsTab.INDEX,
@@ -195,7 +196,7 @@ const TablePage: React.FC<IProps> = function ({
       }
       setPropsTab(nextPropsTab);
     }
-  }, [params.propsTab, params.topTab, isMongoDB]);
+  }, [params.propsTab, params.topTab, isDocumentOrKeyValue]);
 
   const handleTopTabChanged: BasicSegmentedProps['onChange'] = (v) => {
     const topTab = v;
@@ -309,7 +310,7 @@ const TablePage: React.FC<IProps> = function ({
                       },
                       // 外表不展示索引
                       !isExternalTable &&
-                        !isMongoDB && {
+                        !isDocumentOrKeyValue && {
                           key: PropsTab.INDEX,
                           label: formatMessage({
                             id: 'workspace.window.table.propstab.index',
@@ -329,7 +330,7 @@ const TablePage: React.FC<IProps> = function ({
                           })
                         },
 
-                      showPartition && !isMongoDB
+                      showPartition && !isDocumentOrKeyValue
                         ? {
                             key: PropsTab.PARTITION,
                             label: formatMessage({
@@ -339,7 +340,7 @@ const TablePage: React.FC<IProps> = function ({
                             children: <TablePartitions />
                           }
                         : null,
-                      !isMongoDB && {
+                      !isDocumentOrKeyValue && {
                         key: PropsTab.DDL,
                         label: formatMessage({
                           id: 'workspace.window.table.propstab.ddl',

--- a/src/util/mongodb.ts
+++ b/src/util/mongodb.ts
@@ -68,3 +68,12 @@ export function isMongoDBSession(session?: {
 }): boolean {
   return isMongoConnectType(session?.connection?.type);
 }
+
+export function isDocumentOrKeyValueSession(session?: {
+  connection?: { type?: ConnectType };
+}): boolean {
+  return (
+    session?.connection?.type === ConnectType.MONGODB ||
+    session?.connection?.type === ConnectType.REDIS
+  );
+}

--- a/src/util/redis.test.ts
+++ b/src/util/redis.test.ts
@@ -8,6 +8,12 @@ describe('redis copy text', () => {
     );
   });
 
+  test('generates get statement for concrete key', () => {
+    expect(generateRedisCopyText('user:1', DragInsertType.SELECT)).toBe(
+      'GET user:1'
+    );
+  });
+
   test('generates write statements', () => {
     expect(generateRedisCopyText('user:1', DragInsertType.INSERT)).toBe(
       'SET user:1 ${1:value}'

--- a/src/util/redis.test.ts
+++ b/src/util/redis.test.ts
@@ -1,0 +1,22 @@
+import { DragInsertType } from '@/d.ts';
+import { generateRedisCopyText } from './redis';
+
+describe('redis copy text', () => {
+  test('generates scan statement', () => {
+    expect(generateRedisCopyText('user', DragInsertType.SELECT)).toBe(
+      'SCAN 0 MATCH user:* COUNT 100'
+    );
+  });
+
+  test('generates write statements', () => {
+    expect(generateRedisCopyText('user:1', DragInsertType.INSERT)).toBe(
+      'SET user:1 ${1:value}'
+    );
+    expect(generateRedisCopyText('user:1', DragInsertType.UPDATE)).toBe(
+      'SET user:1 ${1:value}'
+    );
+    expect(generateRedisCopyText('user:1', DragInsertType.DELETE)).toBe(
+      'DEL user:1'
+    );
+  });
+});

--- a/src/util/redis.ts
+++ b/src/util/redis.ts
@@ -1,0 +1,39 @@
+import { ConnectType, DragInsertType } from '@/d.ts';
+
+function keyPattern(keyName: string): string {
+  return keyName ? `${keyName}:*` : '*';
+}
+
+export function generateRedisCopyText(
+  keyName: string,
+  copyType: DragInsertType
+): string {
+  switch (copyType) {
+    case DragInsertType.NAME:
+      return keyName;
+    case DragInsertType.SELECT:
+      return `SCAN 0 MATCH ${keyPattern(keyName)} COUNT 100`;
+    case DragInsertType.INSERT:
+      return `SET ${keyName || '${1:key}'} ${
+        keyName ? '${1:value}' : '${2:value}'
+      }`;
+    case DragInsertType.UPDATE:
+      return `SET ${keyName || '${1:key}'} ${
+        keyName ? '${1:value}' : '${2:value}'
+      }`;
+    case DragInsertType.DELETE:
+      return `DEL ${keyName || '${1:key}'}`;
+    default:
+      return '';
+  }
+}
+
+export function isRedisConnectType(type?: ConnectType): boolean {
+  return type === ConnectType.REDIS;
+}
+
+export function isRedisSession(session?: {
+  connection?: { type?: ConnectType };
+}): boolean {
+  return isRedisConnectType(session?.connection?.type);
+}

--- a/src/util/redis.ts
+++ b/src/util/redis.ts
@@ -4,6 +4,10 @@ function keyPattern(keyName: string): string {
   return keyName ? `${keyName}:*` : '*';
 }
 
+function isConcreteKey(keyName: string): boolean {
+  return keyName.includes(':');
+}
+
 export function generateRedisCopyText(
   keyName: string,
   copyType: DragInsertType
@@ -12,6 +16,9 @@ export function generateRedisCopyText(
     case DragInsertType.NAME:
       return keyName;
     case DragInsertType.SELECT:
+      if (keyName && isConcreteKey(keyName)) {
+        return `GET ${keyName}`;
+      }
       return `SCAN 0 MATCH ${keyPattern(keyName)} COUNT 100`;
     case DragInsertType.INSERT:
       return `SET ${keyName || '${1:key}'} ${


### PR DESCRIPTION
## Summary
- Add Redis datasource type helpers and resource tree behavior for SQL console.
- Prevent Redis table nodes from entering relational table paths.

## Related
- Fixes actiontech/dms-ee#873
- Backend PR: https://github.com/actiontech/odc/pull/32
- Base branch: `dev-4.3.4`

## Test plan
- [x] `pnpm type-check`
- [x] DMS `/odc_query/` entry loads ODC frontend assets